### PR TITLE
Handle CORS for chat endpoint

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -18,8 +18,19 @@ export async function POST(req: NextRequest) {
     "Content-Type": "text/event-stream",
     "Cache-Control": "no-cache",
     Connection: "keep-alive",
+    "Access-Control-Allow-Origin": "*",
   });
   headers.forEach((value, key) => resHeaders.append(key, value));
 
   return new Response(stream, { headers: resHeaders });
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- allow CORS preflight for chat API
- expose chat responses over POST with CORS headers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890cd6772748330b9943e3e2d09b82f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled cross-origin requests for the chat API endpoint, allowing integration from external domains.
  * Added support for CORS preflight (OPTIONS) requests to improve compatibility with various clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->