### PR TITLE
fix: handle missing toReadableStream

### DIFF
--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -33,6 +33,13 @@ export async function runAgent(
     ],
   });
 
-  // Convert OpenAI stream into a Web ReadableStream.
-  return (stream as any).toReadableStream();
+  // `client.responses.stream` returns different types depending on the
+  // runtime and library version. In Node/Edge it may already be a
+  // `ReadableStream`, while older versions expose a helper method
+  // `toReadableStream()`. Guard against both cases to avoid runtime
+  // errors when the helper does not exist.
+  const anyStream = stream as any;
+  return typeof anyStream.toReadableStream === "function"
+    ? anyStream.toReadableStream()
+    : (anyStream as ReadableStream);
 }


### PR DESCRIPTION
## Summary
- guard against missing `toReadableStream` helper when streaming responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689153fb03048330a93712b3eae6d18f